### PR TITLE
feat: artist scrobble milestone colours

### DIFF
--- a/fm/bleh.css
+++ b/fm/bleh.css
@@ -3418,6 +3418,17 @@ state is not active, which then falls back to primary button styling */
     margin-right: 6px;
 }
 
+/* these r last.fm default, needed 4 settings preview tho */
+.personal-stats-inner {
+    display: flex;
+    align-items: center;
+}
+.personal-stats-avatar {
+    width: 32px;
+    height: 32px;
+    order: -1;
+}
+
 
 /* ranks */
 .personal-stats-item--scrobbles[data-bleh--scrobble-milestone] {
@@ -11489,6 +11500,21 @@ input[type="range"]::-moz-range-thumb {
 }
 [data-bleh--format_guest_features="false"] {
     .bleh--chartlist-name-with-features {
+        display: none !important;
+    }
+}
+
+.personal-stats-preview {
+    display: flex;
+    justify-content: space-evenly;
+}
+[data-bleh--colourful_counts="true"] {
+    .bleh--personal-stats-if-not-colourful {
+        display: none !important;
+    }
+}
+[data-bleh--colourful_counts="false"] {
+    .bleh--personal-stats-if-colourful {
         display: none !important;
     }
 }

--- a/fm/bleh.css
+++ b/fm/bleh.css
@@ -148,7 +148,8 @@ a,
 .masthead-nav-control,
 .header-new-actions :is(a, button), .header-new-inner, [itemprop="byArtist"] a,
 .user-dashboard-layout .masthead a,
-.bleh--redacted-message
+.bleh--redacted-message,
+.header-metadata-display, .chartlist-count-bar
 {
     --c1: var(--hue), calc(var(--sat) * 40%), 100%;
     --c2: var(--hue), calc(var(--sat) * 60%), 90%;
@@ -3418,6 +3419,86 @@ state is not active, which then falls back to primary button styling */
 }
 
 
+/* ranks */
+.personal-stats-item--scrobbles[data-bleh--scrobble-milestone] {
+    .header-metadata-item {
+        position: relative;
+
+        &:after {
+            content: '';
+            position: absolute;
+            display: block;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            width: 150px;
+            background: linear-gradient(90deg, transparent 0%, hsla(var(--h3), 20%) 100%);
+            border-top-right-radius: var(--item-med-radius);
+            border-bottom-right-radius: var(--item-med-radius);
+            pointer-events: none;
+        }
+    }
+
+
+    .header-metadata-display {
+        color: hsl(var(--l3-c)) !important;
+        text-shadow: 0 0 20px hsl(var(--h4));
+        padding-left: calc(6px + 4px);
+        position: relative;
+
+        [data-bleh--scrobble-milestone="14"] & {
+            --hue: 35;
+            --sat: 1;
+            --lit: 1;
+        }
+
+        &:before {
+            content: '';
+            display: block;
+            background-color: hsl(var(--l3-c)) !important;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            position: absolute;
+            left: 0;
+            top: 50%;
+            margin-top: -3px;
+        }
+    }
+}
+
+.grid-items-item-aux-text {
+    [data-bleh--scrobble-milestone] {
+        /*padding: 0 4px;
+        background-color: hsl(var(--h3));
+        border-radius: var(--item-med-radius);
+        color: hsl(var(--b7));
+        text-shadow: none;
+        font-weight: var(--font-weight-medium);
+        font-size: 12px;
+        line-height: 16px;*/
+        position: relative;
+        padding-left: calc(6px + 4px);
+        color: hsl(var(--l2-c));
+        font-weight: var(--font-weight-medium);
+
+        &:before {
+            content: '';
+            display: block;
+            background-color: hsl(var(--l3-c)) !important;
+            box-shadow: 0 0 30px 7px hsl(var(--h4));
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            position: absolute;
+            left: 0;
+            top: 50%;
+            margin-top: -3px;
+        }
+    }
+}
+
+
 .header-metadata-item, .metadata-item, .header-metadata-tnew-item {
     padding: 7px 12px !important; /* tasteometer overrides with padding-left: 20px */
     background-color: hsla(var(--b4), 50%); /* would be b5, but we have a background */
@@ -3461,7 +3542,7 @@ state is not active, which then falls back to primary button styling */
 
 
 /*     ONLY AVAILABLE VIA ADDON THAT MAKES USE OF THIS     */
-.header-metadata-item:after {
+/*.header-metadata-item:after {
     content: '';
     position: absolute;
     left: 0;
@@ -3475,13 +3556,13 @@ state is not active, which then falls back to primary button styling */
     width: var(--percent, 0%);
     /*box-sizing: border-box;
     border: 2px solid hsla(var(--l3-c), 10%);*/
-    transition-property: opacity, width;
+    /*transition-property: opacity, width;
     transition-duration: 1.3s;
     transition-timing-function: ease;
 }
 .header-metadata-item:not([data-scrobbles]):after {
     opacity: 0;
-}
+}*/
 
 
 /*[data-scrobbles-milestone="0"] {
@@ -4412,7 +4493,7 @@ a.chartlist-love-button:after {
     border-radius: var(--item-small-radius); /* 50 */
 }
 .chartlist-count-bar-slug {
-    background: var(--chartlist-fill) !important;
+    background: hsl(var(--h3)) !important;
     box-shadow: inset hsl(var(--l2-c)) 0 -1px 0, 0px 0px 16px hsla(var(--l3), 50%);
     left: unset;
     right: 0;

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           bleh (dev)
 @namespace      github.com/katelyynn/bleh
-@version        2024.0613
+@version        2024.0614
 @license        GPL-3.0
 @author         kate
 @updateURL      https://github.com/katelyynn/bleh/raw/uwu/fm/bleh.user.css

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -159,7 +159,7 @@ a,
 .header-new-actions :is(a, button), .header-new-inner, [itemprop="byArtist"] a,
 .user-dashboard-layout .masthead a,
 .bleh--redacted-message,
-.header-metadata-display, .header-metadata-item:after
+.header-metadata-display, .chartlist-count-bar
 {
     --c1: var(--hue), calc(var(--sat) * 40%), 100%;
     --c2: var(--hue), calc(var(--sat) * 60%), 90%;
@@ -4503,7 +4503,7 @@ a.chartlist-love-button:after {
     border-radius: var(--item-small-radius); /* 50 */
 }
 .chartlist-count-bar-slug {
-    background: var(--chartlist-fill) !important;
+    background: hsl(var(--h3)) !important;
     box-shadow: inset hsl(var(--l2-c)) 0 -1px 0, 0px 0px 16px hsla(var(--l3), 50%);
     left: unset;
     right: 0;

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -159,7 +159,7 @@ a,
 .header-new-actions :is(a, button), .header-new-inner, [itemprop="byArtist"] a,
 .user-dashboard-layout .masthead a,
 .bleh--redacted-message,
-.header-metadata-display
+.header-metadata-display, .header-metadata-item:after
 {
     --c1: var(--hue), calc(var(--sat) * 40%), 100%;
     --c2: var(--hue), calc(var(--sat) * 60%), 90%;
@@ -3452,8 +3452,15 @@ state is not active, which then falls back to primary button styling */
 
     .header-metadata-display {
         color: hsl(var(--l3-c)) !important;
+        text-shadow: 0 0 20px hsl(var(--h4));
         padding-left: calc(6px + 4px);
         position: relative;
+
+        [data-bleh--scrobble-milestone="14"] & {
+            --hue: 35;
+            --sat: 1;
+            --lit: 1;
+        }
 
         &:before {
             content: '';

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -158,7 +158,8 @@ a,
 .masthead-nav-control,
 .header-new-actions :is(a, button), .header-new-inner, [itemprop="byArtist"] a,
 .user-dashboard-layout .masthead a,
-.bleh--redacted-message
+.bleh--redacted-message,
+.header-metadata-display
 {
     --c1: var(--hue), calc(var(--sat) * 40%), 100%;
     --c2: var(--hue), calc(var(--sat) * 60%), 90%;
@@ -3428,6 +3429,48 @@ state is not active, which then falls back to primary button styling */
 }
 
 
+/* ranks */
+.personal-stats-item--scrobbles {
+    .header-metadata-item {
+        position: relative;
+
+        &:after {
+            content: '';
+            position: absolute;
+            display: block;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            width: 150px;
+            background: linear-gradient(90deg, transparent 0%, hsla(var(--h3), 20%) 100%);
+            border-top-right-radius: var(--item-med-radius);
+            border-bottom-right-radius: var(--item-med-radius);
+            pointer-events: none;
+        }
+    }
+
+
+    .header-metadata-display {
+        color: hsl(var(--l3-c)) !important;
+        padding-left: calc(6px + 4px);
+        position: relative;
+
+        &:before {
+            content: '';
+            display: block;
+            background-color: hsl(var(--l3-c)) !important;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            position: absolute;
+            left: 0;
+            top: 50%;
+            margin-top: -3px;
+        }
+    }
+}
+
+
 .header-metadata-item, .metadata-item, .header-metadata-tnew-item {
     padding: 7px 12px !important; /* tasteometer overrides with padding-left: 20px */
     background-color: hsla(var(--b4), 50%); /* would be b5, but we have a background */
@@ -3471,7 +3514,7 @@ state is not active, which then falls back to primary button styling */
 
 
 /*     ONLY AVAILABLE VIA ADDON THAT MAKES USE OF THIS     */
-.header-metadata-item:after {
+/*.header-metadata-item:after {
     content: '';
     position: absolute;
     left: 0;
@@ -3485,13 +3528,13 @@ state is not active, which then falls back to primary button styling */
     width: var(--percent, 0%);
     /*box-sizing: border-box;
     border: 2px solid hsla(var(--l3-c), 10%);*/
-    transition-property: opacity, width;
+    /*transition-property: opacity, width;
     transition-duration: 1.3s;
     transition-timing-function: ease;
 }
 .header-metadata-item:not([data-scrobbles]):after {
     opacity: 0;
-}
+}*/
 
 
 /*[data-scrobbles-milestone="0"] {

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -3477,6 +3477,37 @@ state is not active, which then falls back to primary button styling */
     }
 }
 
+.grid-items-item-aux-text {
+    [data-kate-processed="true"]:not(.grid-items-item-aux-block) {
+        /*padding: 0 4px;
+        background-color: hsl(var(--h3));
+        border-radius: var(--item-med-radius);
+        color: hsl(var(--b7));
+        text-shadow: none;
+        font-weight: var(--font-weight-medium);
+        font-size: 12px;
+        line-height: 16px;*/
+        position: relative;
+        padding-left: calc(6px + 4px);
+        color: hsl(var(--l2-c));
+        font-weight: var(--font-weight-medium);
+
+        &:before {
+            content: '';
+            display: block;
+            background-color: hsl(var(--l3-c)) !important;
+            box-shadow: 0 0 30px 7px hsl(var(--h4));
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            position: absolute;
+            left: 0;
+            top: 50%;
+            margin-top: -3px;
+        }
+    }
+}
+
 
 .header-metadata-item, .metadata-item, .header-metadata-tnew-item {
     padding: 7px 12px !important; /* tasteometer overrides with padding-left: 20px */

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -3428,6 +3428,17 @@ state is not active, which then falls back to primary button styling */
     margin-right: 6px;
 }
 
+/* these r last.fm default, needed 4 settings preview tho */
+.personal-stats-inner {
+    display: flex;
+    align-items: center;
+}
+.personal-stats-avatar {
+    width: 32px;
+    height: 32px;
+    order: -1;
+}
+
 
 /* ranks */
 .personal-stats-item--scrobbles[data-bleh--scrobble-milestone] {
@@ -11499,6 +11510,21 @@ input[type="range"]::-moz-range-thumb {
 }
 [data-bleh--format_guest_features="false"] {
     .bleh--chartlist-name-with-features {
+        display: none !important;
+    }
+}
+
+.personal-stats-preview {
+    display: flex;
+    justify-content: space-evenly;
+}
+[data-bleh--colourful_counts="true"] {
+    .bleh--personal-stats-if-not-colourful {
+        display: none !important;
+    }
+}
+[data-bleh--colourful_counts="false"] {
+    .bleh--personal-stats-if-colourful {
         display: none !important;
     }
 }

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -3430,7 +3430,7 @@ state is not active, which then falls back to primary button styling */
 
 
 /* ranks */
-.personal-stats-item--scrobbles {
+.personal-stats-item--scrobbles[data-bleh--scrobble-milestone] {
     .header-metadata-item {
         position: relative;
 
@@ -3478,7 +3478,7 @@ state is not active, which then falls back to primary button styling */
 }
 
 .grid-items-item-aux-text {
-    [data-kate-processed="true"]:not(.grid-items-item-aux-block) {
+    [data-bleh--scrobble-milestone] {
         /*padding: 0 4px;
         background-color: hsl(var(--h3));
         border-radius: var(--item-med-radius);

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         bleh
 // @namespace    http://last.fm/
-// @version      2024.0613
+// @version      2024.0614
 // @description  bleh!!! ^-^
 // @author       kate
 // @match        https://www.last.fm/*
@@ -15,7 +15,7 @@
 // @require      https://unpkg.com/tippy.js@6
 // ==/UserScript==
 
-let version = '2024.0613';
+let version = '2024.0614';
 
 tippy.setDefaultProps({
     arrow: false,

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -109,29 +109,29 @@ let ranks = {
         lit: 0.925
     },
     10: {
-        hue: 350,
+        hue: -7,
         sat: 1.5,
         lit: 0.875
     },
     11: {
-        hue: 332,
+        hue: -25,
         sat: 1.5,
         lit: 0.875
     },
     12: {
-        hue: 290,
+        hue: -55,
         sat: 0.875,
         lit: 0.85
     },
     13: {
-        hue: 246,
+        hue: -85,
         sat: 1.2,
         lit: 0.9
     },
     14: {
-        hue: 240,
-        sat: 1,
-        lit: 0.7
+        hue: -105,
+        sat: 0.9,
+        lit: 0.8
     }
 }
 
@@ -403,6 +403,7 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
             patch_titles(document.body);
             patch_header_title(document.body);
             patch_artist_ranks(document.body);
+            patch_artist_ranks_in_grid_view(document.body);
         }
 
         // last.fm is a single page application
@@ -426,6 +427,7 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
                                 patch_titles(document.body);
                                 patch_header_title(document.body);
                                 patch_artist_ranks(document.body);
+                                patch_artist_ranks_in_grid_view(document.body);
                             }
                         }
                     }
@@ -1063,7 +1065,7 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
 
     // artist ranks
     function patch_artist_ranks(element) {
-        let personal_statistic = document.querySelector('.personal-stats-item--scrobbles');
+        let personal_statistic = element.querySelector('.personal-stats-item--scrobbles');
 
         if (personal_statistic == undefined)
             return;
@@ -1072,79 +1074,119 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
             personal_statistic.setAttribute('data-kate-processed','true');
 
             let scrobbles = parseInt(personal_statistic.querySelector('.link-block-target').textContent.replaceAll(',',''));
-            let scrobble_milestone = 0;
-            let scrobble_proximity = 0;
+            let parsed_scrobble_as_rank = parse_scrobbles_as_rank(scrobbles);
 
-            if (scrobbles > 75_000) {
-                scrobble_milestone = 14; scrobble_proximity = 1;
-            } else if (scrobbles > 65_000) {
-                scrobble_milestone = 13; scrobble_proximity = (scrobbles - 50_000) / 75_000;
-            } else if (scrobbles > 50_000) {
-                scrobble_milestone = 12; scrobble_proximity = (scrobbles - 40_000) / 65_000;
-            } else if (scrobbles > 40_000) {
-                scrobble_milestone = 11; scrobble_proximity = (scrobbles - 30_000) / 50_000;
-            } else if (scrobbles > 30_000) {
-                scrobble_milestone = 10; scrobble_proximity = (scrobbles - 20_000) / 40_000;
-            } else if (scrobbles > 20_000) {
-                scrobble_milestone = 9; scrobble_proximity = (scrobbles - 10_000) / 30_000;
-            } else if (scrobbles > 10_000) {
-                scrobble_milestone = 8; scrobble_proximity = (scrobbles - 8_000) / 20_000;
-            } else if (scrobbles > 8_000) {
-                scrobble_milestone = 7; scrobble_proximity = (scrobbles - 5_000) / 10_000;
-            } else if (scrobbles > 5_000) {
-                scrobble_milestone = 6; scrobble_proximity = (scrobbles - 3_500) / 8_000;
-            } else if (scrobbles > 3_500) {
-                scrobble_milestone = 5; scrobble_proximity = (scrobbles - 2_000) / 5_000;
-            } else if (scrobbles > 2_000) {
-                scrobble_milestone = 4; scrobble_proximity = (scrobbles - 1_000) / 3_500;
-            } else if (scrobbles > 1_000) {
-                scrobble_milestone = 3; scrobble_proximity = (scrobbles - 500) / 2_000;
-            } else if (scrobbles > 500) {
-                scrobble_milestone = 2; scrobble_proximity = (scrobbles - 300) / 1_000;
-            } else if (scrobbles > 300) {
-                scrobble_milestone = 1; scrobble_proximity = (scrobbles - 100) / 500;
-            } else if (scrobbles > 100) {
-                scrobble_milestone = 0; scrobble_proximity = scrobbles / 300;
-            }
-
-            let milestone_hue = ranks[scrobble_milestone].hue;
-            let milestone_sat = ranks[scrobble_milestone].sat;
-            let milestone_lit = ranks[scrobble_milestone].lit;
-
-            console.info('bleh - default values will be', milestone_hue, milestone_sat, milestone_lit);
-
-            if (scrobble_milestone != 14) {
-                let next_milestone_hue = ranks[scrobble_milestone + 1].hue;
-                let next_milestone_sat = ranks[scrobble_milestone + 1].sat;
-                let next_milestone_lit = ranks[scrobble_milestone + 1].lit;
-
-                console.info('bleh - next up values will be', next_milestone_hue, next_milestone_sat, next_milestone_lit);
-
-                if (milestone_hue > next_milestone_hue)
-                    milestone_hue += (next_milestone_hue - milestone_hue) * scrobble_proximity;
-
-                if (milestone_sat < next_milestone_sat)
-                    milestone_sat += (milestone_sat - next_milestone_sat) * scrobble_proximity;
-                else
-                    milestone_sat += (next_milestone_sat - milestone_sat) * scrobble_proximity;
-
-                if (milestone_lit < next_milestone_lit)
-                    milestone_lit += (milestone_lit - next_milestone_lit) * scrobble_proximity;
-                else
-                    milestone_lit += (next_milestone_lit - milestone_lit) * scrobble_proximity;
-
-                console.info('bleh - created proximity values', milestone_hue, milestone_sat, milestone_lit);
-            }
-
-
-
-            console.info('bleh - scrobble milestone for artist is',scrobble_milestone,'with',scrobbles,'scrobbles','- scrobble proximity of',scrobble_proximity);
-
-            personal_statistic.setAttribute('data-bleh--scrobble-milestone',scrobble_milestone);
-            personal_statistic.style.setProperty('--hue',milestone_hue);
-            personal_statistic.style.setProperty('--sat',milestone_sat);
-            personal_statistic.style.setProperty('--lit',milestone_lit);
+            personal_statistic.setAttribute('data-bleh--scrobble-milestone',parsed_scrobble_as_rank.milestone);
+            personal_statistic.style.setProperty('--hue',parsed_scrobble_as_rank.hue);
+            personal_statistic.style.setProperty('--sat',parsed_scrobble_as_rank.sat);
+            personal_statistic.style.setProperty('--lit',parsed_scrobble_as_rank.lit);
         }
+    }
+
+    function patch_artist_ranks_in_grid_view(element) {
+        let artist_statistics = element.querySelectorAll('.grid-items-item-aux-text a');
+
+        console.info('artist statistic', artist_statistics);
+
+        if (artist_statistics == undefined)
+            return;
+
+        artist_statistics.forEach((artist_statistic) => {
+            if (!artist_statistic.hasAttribute('data-kate-processed')) {
+                artist_statistic.setAttribute('data-kate-processed','true');
+
+                if (!artist_statistic.getAttribute('href').endsWith('DAYS') && !artist_statistic.classList.contains('grid-items-item-aux-block')) {
+                    console.info('bleh - artist grid plays match');
+
+                    let scrobbles = parseInt(artist_statistic.textContent.replaceAll(',','').replace(' plays',''));
+                    let parsed_scrobble_as_rank = parse_scrobbles_as_rank(scrobbles);
+
+                    artist_statistic.setAttribute('data-bleh--scrobble-milestone',parsed_scrobble_as_rank.milestone);
+                    artist_statistic.style.setProperty('--hue',parsed_scrobble_as_rank.hue);
+                    artist_statistic.style.setProperty('--sat',parsed_scrobble_as_rank.sat);
+                    artist_statistic.style.setProperty('--lit',parsed_scrobble_as_rank.lit);
+                }
+            }
+        });
+    }
+
+
+    function parse_scrobbles_as_rank(scrobbles) {
+        let scrobble_milestone = 0;
+        let scrobble_proximity = 0;
+
+        if (scrobbles > 30_000) {
+            scrobble_milestone = 14; scrobble_proximity = 1;
+        } else if (scrobbles > 18_000) {
+            scrobble_milestone = 13; scrobble_proximity = (scrobbles - 50_000) / 75_000;
+        } else if (scrobbles > 13_000) {
+            scrobble_milestone = 12; scrobble_proximity = (scrobbles - 40_000) / 65_000;
+        } else if (scrobbles > 8_200) {
+            scrobble_milestone = 11; scrobble_proximity = (scrobbles - 30_000) / 50_000;
+        } else if (scrobbles > 6_900) {
+            scrobble_milestone = 10; scrobble_proximity = (scrobbles - 20_000) / 40_000;
+        } else if (scrobbles > 5_400) {
+            scrobble_milestone = 9; scrobble_proximity = (scrobbles - 10_000) / 30_000;
+        } else if (scrobbles > 4_600) {
+            scrobble_milestone = 8; scrobble_proximity = (scrobbles - 8_000) / 20_000;
+        } else if (scrobbles > 3_500) {
+            scrobble_milestone = 7; scrobble_proximity = (scrobbles - 5_000) / 10_000;
+        } else if (scrobbles > 2_550) {
+            scrobble_milestone = 6; scrobble_proximity = (scrobbles - 3_500) / 8_000;
+        } else if (scrobbles > 1_900) {
+            scrobble_milestone = 5; scrobble_proximity = (scrobbles - 2_000) / 5_000;
+        } else if (scrobbles > 1_300) {
+            scrobble_milestone = 4; scrobble_proximity = (scrobbles - 1_000) / 3_500;
+        } else if (scrobbles > 1_000) {
+            scrobble_milestone = 3; scrobble_proximity = (scrobbles - 500) / 2_000;
+        } else if (scrobbles > 500) {
+            scrobble_milestone = 2; scrobble_proximity = (scrobbles - 300) / 1_000;
+        } else if (scrobbles > 300) {
+            scrobble_milestone = 1; scrobble_proximity = (scrobbles - 100) / 500;
+        } else if (scrobbles > 100) {
+            scrobble_milestone = 0; scrobble_proximity = scrobbles / 300;
+        }
+
+        let milestone_hue = ranks[scrobble_milestone].hue;
+        let milestone_sat = ranks[scrobble_milestone].sat;
+        let milestone_lit = ranks[scrobble_milestone].lit;
+
+        console.info('bleh - default values will be', milestone_hue, milestone_sat, milestone_lit);
+
+        if (scrobble_milestone != 14) {
+            let next_milestone_hue = ranks[scrobble_milestone + 1].hue;
+            let next_milestone_sat = ranks[scrobble_milestone + 1].sat;
+            let next_milestone_lit = ranks[scrobble_milestone + 1].lit;
+
+            console.info('bleh - next up values will be', next_milestone_hue, next_milestone_sat, next_milestone_lit);
+
+            if (milestone_hue > next_milestone_hue)
+                milestone_hue += (next_milestone_hue - milestone_hue) * scrobble_proximity;
+
+            if (milestone_sat < next_milestone_sat)
+                milestone_sat += (milestone_sat - next_milestone_sat) * scrobble_proximity;
+            else
+                milestone_sat += (next_milestone_sat - milestone_sat) * scrobble_proximity;
+
+            if (milestone_lit < next_milestone_lit)
+                milestone_lit += (milestone_lit - next_milestone_lit) * scrobble_proximity;
+            else
+                milestone_lit += (next_milestone_lit - milestone_lit) * scrobble_proximity;
+
+            console.info('bleh - created proximity values', milestone_hue, milestone_sat, milestone_lit);
+        }
+
+
+
+        console.info('bleh - scrobble milestone for artist is',scrobble_milestone,'with',scrobbles,'scrobbles','- scrobble proximity of',scrobble_proximity);
+
+        return {
+            milestone: scrobble_milestone,
+            proximity: scrobble_proximity,
+            hue: milestone_hue,
+            sat: milestone_sat,
+            lit: milestone_lit
+        };
     }
 
 

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -66,7 +66,7 @@ let ranks = {
     1: {
         hue: 180,
         sat: 1.5,
-        lit: 0.925
+        lit: 0.875
     },
     2: {
         hue: 160,
@@ -131,7 +131,7 @@ let ranks = {
     14: {
         hue: 240,
         sat: 1,
-        lit: 0.575
+        lit: 0.7
     }
 }
 
@@ -1076,43 +1076,74 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
             let scrobble_proximity = 0;
 
             if (scrobbles > 75_000) {
-                scrobble_milestone = 14; scrobble_proximity = (scrobbles - 65_000) / 75_000;
+                scrobble_milestone = 14; scrobble_proximity = 1;
             } else if (scrobbles > 65_000) {
-                scrobble_milestone = 13; scrobble_proximity = (scrobbles - 50_000) / 65_000;
+                scrobble_milestone = 13; scrobble_proximity = (scrobbles - 50_000) / 75_000;
             } else if (scrobbles > 50_000) {
-                scrobble_milestone = 12; scrobble_proximity = (scrobbles - 40_000) / 50_000;
+                scrobble_milestone = 12; scrobble_proximity = (scrobbles - 40_000) / 65_000;
             } else if (scrobbles > 40_000) {
-                scrobble_milestone = 11; scrobble_proximity = (scrobbles - 30_000) / 40_000;
+                scrobble_milestone = 11; scrobble_proximity = (scrobbles - 30_000) / 50_000;
             } else if (scrobbles > 30_000) {
-                scrobble_milestone = 10; scrobble_proximity = (scrobbles - 20_000) / 30_000;
+                scrobble_milestone = 10; scrobble_proximity = (scrobbles - 20_000) / 40_000;
             } else if (scrobbles > 20_000) {
-                scrobble_milestone = 9; scrobble_proximity = (scrobbles - 10_000) / 20_000;
+                scrobble_milestone = 9; scrobble_proximity = (scrobbles - 10_000) / 30_000;
             } else if (scrobbles > 10_000) {
-                scrobble_milestone = 8; scrobble_proximity = (scrobbles - 8_000) / 10_000;
+                scrobble_milestone = 8; scrobble_proximity = (scrobbles - 8_000) / 20_000;
             } else if (scrobbles > 8_000) {
-                scrobble_milestone = 7; scrobble_proximity = (scrobbles - 5_000) / 8_000;
+                scrobble_milestone = 7; scrobble_proximity = (scrobbles - 5_000) / 10_000;
             } else if (scrobbles > 5_000) {
-                scrobble_milestone = 6; scrobble_proximity = (scrobbles - 3_500) / 5_000;
+                scrobble_milestone = 6; scrobble_proximity = (scrobbles - 3_500) / 8_000;
             } else if (scrobbles > 3_500) {
-                scrobble_milestone = 5; scrobble_proximity = (scrobbles - 2_000) / 3_500;
+                scrobble_milestone = 5; scrobble_proximity = (scrobbles - 2_000) / 5_000;
             } else if (scrobbles > 2_000) {
-                scrobble_milestone = 4; scrobble_proximity = (scrobbles - 1_000) / 2_000;
+                scrobble_milestone = 4; scrobble_proximity = (scrobbles - 1_000) / 3_500;
             } else if (scrobbles > 1_000) {
-                scrobble_milestone = 3; scrobble_proximity = (scrobbles - 500) / 1_000;
+                scrobble_milestone = 3; scrobble_proximity = (scrobbles - 500) / 2_000;
             } else if (scrobbles > 500) {
-                scrobble_milestone = 2; scrobble_proximity = (scrobbles - 300) / 500;
+                scrobble_milestone = 2; scrobble_proximity = (scrobbles - 300) / 1_000;
             } else if (scrobbles > 300) {
-                scrobble_milestone = 1; scrobble_proximity = (scrobbles - 100) / 300;
+                scrobble_milestone = 1; scrobble_proximity = (scrobbles - 100) / 500;
             } else if (scrobbles > 100) {
-                scrobble_milestone = 0; scrobble_proximity = scrobbles / 100;
+                scrobble_milestone = 0; scrobble_proximity = scrobbles / 300;
             }
+
+            let milestone_hue = ranks[scrobble_milestone].hue;
+            let milestone_sat = ranks[scrobble_milestone].sat;
+            let milestone_lit = ranks[scrobble_milestone].lit;
+
+            console.info('bleh - default values will be', milestone_hue, milestone_sat, milestone_lit);
+
+            if (scrobble_milestone != 14) {
+                let next_milestone_hue = ranks[scrobble_milestone + 1].hue;
+                let next_milestone_sat = ranks[scrobble_milestone + 1].sat;
+                let next_milestone_lit = ranks[scrobble_milestone + 1].lit;
+
+                console.info('bleh - next up values will be', next_milestone_hue, next_milestone_sat, next_milestone_lit);
+
+                if (milestone_hue > next_milestone_hue)
+                    milestone_hue += (next_milestone_hue - milestone_hue) * scrobble_proximity;
+
+                if (milestone_sat < next_milestone_sat)
+                    milestone_sat += (milestone_sat - next_milestone_sat) * scrobble_proximity;
+                else
+                    milestone_sat += (next_milestone_sat - milestone_sat) * scrobble_proximity;
+
+                if (milestone_lit < next_milestone_lit)
+                    milestone_lit += (milestone_lit - next_milestone_lit) * scrobble_proximity;
+                else
+                    milestone_lit += (next_milestone_lit - milestone_lit) * scrobble_proximity;
+
+                console.info('bleh - created proximity values', milestone_hue, milestone_sat, milestone_lit);
+            }
+
+
 
             console.info('bleh - scrobble milestone for artist is',scrobble_milestone,'with',scrobbles,'scrobbles','- scrobble proximity of',scrobble_proximity);
 
             personal_statistic.setAttribute('data-bleh--scrobble-milestone',scrobble_milestone);
-            personal_statistic.style.setProperty('--hue',ranks[scrobble_milestone].hue);
-            personal_statistic.style.setProperty('--sat',ranks[scrobble_milestone].sat);
-            personal_statistic.style.setProperty('--lit',ranks[scrobble_milestone].lit);
+            personal_statistic.style.setProperty('--hue',milestone_hue);
+            personal_statistic.style.setProperty('--sat',milestone_sat);
+            personal_statistic.style.setProperty('--lit',milestone_lit);
         }
     }
 

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -58,80 +58,95 @@ let song_title_corrections = {
 };
 
 let ranks = {
-    0: {
-        hue: 200,
-        sat: 1.5,
-        lit: 0.925
+    14: {
+        start: 50_000,
+        hue: -105,
+        sat: 0.9,
+        lit: 0.8
     },
-    1: {
-        hue: 180,
-        sat: 1.5,
-        lit: 0.875
-    },
-    2: {
-        hue: 160,
-        sat: 1.5,
-        lit: 0.925
-    },
-    3: {
-        hue: 148,
-        sat: 1.35,
-        lit: 0.925
-    },
-    4: {
-        hue: 130,
-        sat: 1.35,
-        lit: 0.925
-    },
-    5: {
-        hue: 103,
-        sat: 1.35,
-        lit: 0.925
-    },
-    6: {
-        hue: 80,
-        sat: 1.35,
-        lit: 0.925
-    },
-    7: {
-        hue: 60,
-        sat: 1.375,
+    13: {
+        start: 38_000,
+        hue: -85,
+        sat: 1.2,
         lit: 0.95
     },
-    8: {
-        hue: 25,
-        sat: 1.425,
-        lit: 0.925
-    },
-    9: {
-        hue: 4,
-        sat: 1.425,
-        lit: 0.925
-    },
-    10: {
-        hue: -7,
-        sat: 1.5,
-        lit: 0.875
-    },
-    11: {
-        hue: -25,
-        sat: 1.5,
-        lit: 0.875
-    },
     12: {
+        start: 24_000,
         hue: -55,
         sat: 0.875,
         lit: 0.85
     },
-    13: {
-        hue: -85,
-        sat: 1.2,
+    11: {
+        start: 16_000,
+        hue: -25,
+        sat: 1.5,
+        lit: 0.875
+    },
+    10: {
+        start: 12_500,
+        hue: -7,
+        sat: 1.5,
+        lit: 0.875
+    },
+    9: {
+        start: 6_000,
+        hue: 4,
+        sat: 1.425,
         lit: 0.9
     },
-    14: {
-        hue: -105,
-        sat: 0.9,
-        lit: 0.8
+    8: {
+        start: 4_300,
+        hue: 25,
+        sat: 1.425,
+        lit: 0.925
+    },
+    7: {
+        start: 3_200,
+        hue: 60,
+        sat: 1.375,
+        lit: 0.95
+    },
+    6: {
+        start: 2_250,
+        hue: 80,
+        sat: 1.35,
+        lit: 0.925
+    },
+    5: {
+        start: 1_500,
+        hue: 103,
+        sat: 1.35,
+        lit: 0.925
+    },
+    4: {
+        start: 1_000,
+        hue: 130,
+        sat: 1.35,
+        lit: 0.925
+    },
+    3: {
+        start: 500,
+        hue: 148,
+        sat: 1.35,
+        lit: 0.925
+    },
+    2: {
+        start: 300,
+        hue: 160,
+        sat: 1.5,
+        lit: 0.925
+    },
+    1: {
+        start: 100,
+        hue: 180,
+        sat: 1.5,
+        lit: 0.875
+    },
+    0: {
+        start: 0,
+        hue: 200,
+        sat: 1.5,
+        lit: 0.925
     }
 }
 
@@ -1065,7 +1080,7 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
 
     // artist ranks
     function patch_artist_ranks(element) {
-        let personal_statistic = element.querySelector('.personal-stats-item--scrobbles');
+        let personal_statistic = element.querySelector('.header-new--artist + .page-content .personal-stats-item--scrobbles');
 
         if (personal_statistic == undefined)
             return;
@@ -1116,6 +1131,10 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
         if (count_bar == undefined)
             return;
 
+        let count_bar_link = count_bar.querySelector('.chartlist-count-bar-link');
+        if (count_bar_link.getAttribute('href').endsWith('DAYS'))
+            return;
+
         let count = parseInt(count_bar.querySelector('.chartlist-count-bar-value').textContent.replaceAll(',','').replace(' scrobbles',''));
         console.info('count', count);
 
@@ -1134,38 +1153,24 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
 
     function parse_scrobbles_as_rank(scrobbles) {
         let scrobble_milestone = 0;
-        let scrobble_proximity = 0;
+        let scrobble_proximity = 1;
 
-        if (scrobbles > 50_000) {
-            scrobble_milestone = 14; scrobble_proximity = 1;
-        } else if (scrobbles > 20_000) {
-            scrobble_milestone = 13; scrobble_proximity = (scrobbles - 13_000) / 50_000;
-        } else if (scrobbles > 13_000) {
-            scrobble_milestone = 12; scrobble_proximity = (scrobbles - 8_200) / 20_000;
-        } else if (scrobbles > 8_200) {
-            scrobble_milestone = 11; scrobble_proximity = (scrobbles - 6_900) / 13_000;
-        } else if (scrobbles > 6_900) {
-            scrobble_milestone = 10; scrobble_proximity = (scrobbles - 5_400) / 8_200;
-        } else if (scrobbles > 5_400) {
-            scrobble_milestone = 9; scrobble_proximity = (scrobbles - 4_600) / 6_900;
-        } else if (scrobbles > 4_600) {
-            scrobble_milestone = 8; scrobble_proximity = (scrobbles - 3_500) / 5_400;
-        } else if (scrobbles > 3_500) {
-            scrobble_milestone = 7; scrobble_proximity = (scrobbles - 2_550) / 4_600;
-        } else if (scrobbles > 2_550) {
-            scrobble_milestone = 6; scrobble_proximity = (scrobbles - 1_900) / 3_500;
-        } else if (scrobbles > 1_900) {
-            scrobble_milestone = 5; scrobble_proximity = (scrobbles - 1_300) / 2_550;
-        } else if (scrobbles > 1_300) {
-            scrobble_milestone = 4; scrobble_proximity = (scrobbles - 1_000) / 1_900;
-        } else if (scrobbles > 1_000) {
-            scrobble_milestone = 3; scrobble_proximity = (scrobbles - 500) / 1_300;
-        } else if (scrobbles > 500) {
-            scrobble_milestone = 2; scrobble_proximity = (scrobbles - 300) / 1_000;
-        } else if (scrobbles > 300) {
-            scrobble_milestone = 1; scrobble_proximity = (scrobbles - 100) / 500;
-        } else if (scrobbles > 100) {
-            scrobble_milestone = 0; scrobble_proximity = scrobbles / 300;
+        for (let rank = 14; rank >= 0; rank--) {
+            if (scrobbles > ranks[rank].start) {
+                console.info('bleh - PARSING RANK:', rank, ranks[rank].start);
+
+                let this_rank = parseInt(rank);
+
+                scrobble_milestone = this_rank;
+
+                let next_rank = this_rank + 1;
+                let prev_rank = this_rank - 1;
+
+                if (this_rank != 14 && this_rank != 0)
+                    scrobble_proximity = (scrobbles - ranks[prev_rank].start) / ranks[next_rank].start;
+
+                break;
+            }
         }
 
         let milestone_hue = ranks[scrobble_milestone].hue;
@@ -2390,20 +2395,24 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
 
                 // image
                 let track_image = track.querySelector('.chartlist-image span');
-                let track_image_img = track_image.querySelector('img');
-                tippy(track_image, {
-                    content: track_image_img.getAttribute('alt')
-                })
+
+                if (track_image != undefined) {
+                    let track_image_img = track_image.querySelector('img');
+                    tippy(track_image, {
+                        content: track_image_img.getAttribute('alt')
+                    })
 
 
-                // artist statistic
-                if (track_image.classList.contains('avatar')) {
-                    patch_artist_ranks_in_list_view(track);
-                    return;
+                    // artist statistic
+                    if (track_image.classList.contains('avatar')) {
+                        patch_artist_ranks_in_list_view(track);
+                        return;
+                    }
                 }
 
                 if (settings.format_guest_features) {
                     let track_title = track.querySelector('.chartlist-name a');
+                    console.info('bleh - guest features, track title:', track_title);
 
                     if (track_title == undefined)
                         return;

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -1136,30 +1136,30 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
         let scrobble_milestone = 0;
         let scrobble_proximity = 0;
 
-        if (scrobbles > 30_000) {
+        if (scrobbles > 50_000) {
             scrobble_milestone = 14; scrobble_proximity = 1;
-        } else if (scrobbles > 18_000) {
-            scrobble_milestone = 13; scrobble_proximity = (scrobbles - 50_000) / 75_000;
+        } else if (scrobbles > 20_000) {
+            scrobble_milestone = 13; scrobble_proximity = (scrobbles - 13_000) / 50_000;
         } else if (scrobbles > 13_000) {
-            scrobble_milestone = 12; scrobble_proximity = (scrobbles - 40_000) / 65_000;
+            scrobble_milestone = 12; scrobble_proximity = (scrobbles - 8_200) / 20_000;
         } else if (scrobbles > 8_200) {
-            scrobble_milestone = 11; scrobble_proximity = (scrobbles - 30_000) / 50_000;
+            scrobble_milestone = 11; scrobble_proximity = (scrobbles - 6_900) / 13_000;
         } else if (scrobbles > 6_900) {
-            scrobble_milestone = 10; scrobble_proximity = (scrobbles - 20_000) / 40_000;
+            scrobble_milestone = 10; scrobble_proximity = (scrobbles - 5_400) / 8_200;
         } else if (scrobbles > 5_400) {
-            scrobble_milestone = 9; scrobble_proximity = (scrobbles - 10_000) / 30_000;
+            scrobble_milestone = 9; scrobble_proximity = (scrobbles - 4_600) / 6_900;
         } else if (scrobbles > 4_600) {
-            scrobble_milestone = 8; scrobble_proximity = (scrobbles - 8_000) / 20_000;
+            scrobble_milestone = 8; scrobble_proximity = (scrobbles - 3_500) / 5_400;
         } else if (scrobbles > 3_500) {
-            scrobble_milestone = 7; scrobble_proximity = (scrobbles - 5_000) / 10_000;
+            scrobble_milestone = 7; scrobble_proximity = (scrobbles - 2_550) / 4_600;
         } else if (scrobbles > 2_550) {
-            scrobble_milestone = 6; scrobble_proximity = (scrobbles - 3_500) / 8_000;
+            scrobble_milestone = 6; scrobble_proximity = (scrobbles - 1_900) / 3_500;
         } else if (scrobbles > 1_900) {
-            scrobble_milestone = 5; scrobble_proximity = (scrobbles - 2_000) / 5_000;
+            scrobble_milestone = 5; scrobble_proximity = (scrobbles - 1_300) / 2_550;
         } else if (scrobbles > 1_300) {
-            scrobble_milestone = 4; scrobble_proximity = (scrobbles - 1_000) / 3_500;
+            scrobble_milestone = 4; scrobble_proximity = (scrobbles - 1_000) / 1_900;
         } else if (scrobbles > 1_000) {
-            scrobble_milestone = 3; scrobble_proximity = (scrobbles - 500) / 2_000;
+            scrobble_milestone = 3; scrobble_proximity = (scrobbles - 500) / 1_300;
         } else if (scrobbles > 500) {
             scrobble_milestone = 2; scrobble_proximity = (scrobbles - 300) / 1_000;
         } else if (scrobbles > 300) {
@@ -2369,17 +2369,45 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
     function patch_titles(element) {
         let settings = JSON.parse(localStorage.getItem('bleh')) || create_settings_template();
 
-        if (settings.format_guest_features) {
-            try {
-            let tracks = element.querySelectorAll('.chartlist-row:not(.chartlist__placeholder-row)');
+        let tracks = element.querySelectorAll('.chartlist-row:not(.chartlist__placeholder-row)');
 
-            tracks.forEach((track) => {
-                if (!track.hasAttribute('data-kate-processed')) {
-                    track.setAttribute('data-kate-processed','true');
+        if (tracks == undefined)
+            return;
 
-                    console.log(track);
+        tracks.forEach((track => {
+            if (!track.hasAttribute('data-kate-processed')) {
+                track.setAttribute('data-kate-processed','true');
 
+                // duration
+                let track_timestamp = track.querySelector('.chartlist-timestamp span');
+                if (track_timestamp != undefined) {
+                    tippy(track_timestamp, {
+                        content: track_timestamp.getAttribute('title')
+                    });
+                    track_timestamp.setAttribute('title','');
+                }
+
+
+                // image
+                let track_image = track.querySelector('.chartlist-image span');
+                let track_image_img = track_image.querySelector('img');
+                tippy(track_image, {
+                    content: track_image_img.getAttribute('alt')
+                })
+
+
+                // artist statistic
+                if (track_image.classList.contains('avatar')) {
+                    patch_artist_ranks_in_list_view(track);
+                    return;
+                }
+
+                if (settings.format_guest_features) {
                     let track_title = track.querySelector('.chartlist-name a');
+
+                    if (track_title == undefined)
+                        return;
+
                     let track_artist = track_title.getAttribute('href').split('/')[2].replaceAll('+',' ');
 
                     let formatted_title = name_includes(track_title.textContent, track_artist);
@@ -2413,34 +2441,9 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
                             }
                         }
                     }
-
-
-
-                    // duration
-                    let track_timestamp = track.querySelector('.chartlist-timestamp span');
-                    if (track_timestamp != undefined) {
-                        tippy(track_timestamp, {
-                            content: track_timestamp.getAttribute('title')
-                        });
-                        track_timestamp.setAttribute('title','');
-                    }
-
-
-                    // image
-                    let track_image = track.querySelector('.chartlist-image span');
-                    let track_image_img = track_image.querySelector('img');
-                    tippy(track_image, {
-                        content: track_image_img.getAttribute('alt')
-                    })
-
-
-                    // artist statistic
-                    if (track_image.classList.contains('avatar'))
-                        patch_artist_ranks_in_list_view(track);
                 }
-            });
-            } catch(e) {console.error('AA',e)}
-        }
+            }
+        }));
     }
 
     function patch_header_title(element) {

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -1073,39 +1073,41 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
 
             let scrobbles = parseInt(personal_statistic.querySelector('.link-block-target').textContent.replaceAll(',',''));
             let scrobble_milestone = 0;
+            let scrobble_proximity = 0;
 
-            if (scrobbles > 150_000)
-                scrobble_milestone = 14;
-            else if (scrobbles > 100_000)
-                scrobble_milestone = 13;
-            else if (scrobbles > 75_000)
-                scrobble_milestone = 12;
-            else if (scrobbles > 65_000)
-                scrobble_milestone = 11;
-            else if (scrobbles > 50_000)
-                scrobble_milestone = 10;
-            else if (scrobbles > 35_000)
-                scrobble_milestone = 9;
-            else if (scrobbles > 25_000)
-                scrobble_milestone = 8;
-            else if (scrobbles > 15_000)
-                scrobble_milestone = 7;
-            else if (scrobbles > 9_000)
-                scrobble_milestone = 6;
-            else if (scrobbles > 5_000)
-                scrobble_milestone = 5;
-            else if (scrobbles > 3_500)
-                scrobble_milestone = 4;
-            else if (scrobbles > 2_000)
-                scrobble_milestone = 3;
-            else if (scrobbles > 1_000)
-                scrobble_milestone = 2;
-            else if (scrobbles > 500)
-                scrobble_milestone = 1;
-            else if (scrobbles > 100)
-                scrobble_milestone = 0;
+            if (scrobbles > 75_000) {
+                scrobble_milestone = 14; scrobble_proximity = (scrobbles - 65_000) / 75_000;
+            } else if (scrobbles > 65_000) {
+                scrobble_milestone = 13; scrobble_proximity = (scrobbles - 50_000) / 65_000;
+            } else if (scrobbles > 50_000) {
+                scrobble_milestone = 12; scrobble_proximity = (scrobbles - 40_000) / 50_000;
+            } else if (scrobbles > 40_000) {
+                scrobble_milestone = 11; scrobble_proximity = (scrobbles - 30_000) / 40_000;
+            } else if (scrobbles > 30_000) {
+                scrobble_milestone = 10; scrobble_proximity = (scrobbles - 20_000) / 30_000;
+            } else if (scrobbles > 20_000) {
+                scrobble_milestone = 9; scrobble_proximity = (scrobbles - 10_000) / 20_000;
+            } else if (scrobbles > 10_000) {
+                scrobble_milestone = 8; scrobble_proximity = (scrobbles - 8_000) / 10_000;
+            } else if (scrobbles > 8_000) {
+                scrobble_milestone = 7; scrobble_proximity = (scrobbles - 5_000) / 8_000;
+            } else if (scrobbles > 5_000) {
+                scrobble_milestone = 6; scrobble_proximity = (scrobbles - 3_500) / 5_000;
+            } else if (scrobbles > 3_500) {
+                scrobble_milestone = 5; scrobble_proximity = (scrobbles - 2_000) / 3_500;
+            } else if (scrobbles > 2_000) {
+                scrobble_milestone = 4; scrobble_proximity = (scrobbles - 1_000) / 2_000;
+            } else if (scrobbles > 1_000) {
+                scrobble_milestone = 3; scrobble_proximity = (scrobbles - 500) / 1_000;
+            } else if (scrobbles > 500) {
+                scrobble_milestone = 2; scrobble_proximity = (scrobbles - 300) / 500;
+            } else if (scrobbles > 300) {
+                scrobble_milestone = 1; scrobble_proximity = (scrobbles - 100) / 300;
+            } else if (scrobbles > 100) {
+                scrobble_milestone = 0; scrobble_proximity = scrobbles / 100;
+            }
 
-            console.info('bleh - scrobble milestone for artist is',scrobble_milestone,'with',scrobbles,'scrobbles');
+            console.info('bleh - scrobble milestone for artist is',scrobble_milestone,'with',scrobbles,'scrobbles','- scrobble proximity of',scrobble_proximity);
 
             personal_statistic.setAttribute('data-bleh--scrobble-milestone',scrobble_milestone);
             personal_statistic.style.setProperty('--hue',ranks[scrobble_milestone].hue);

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -281,7 +281,8 @@ let settings_template = {
     accessible_name_colours: false,
     underline_links: false,
     big_numbers: false,
-    format_guest_features: true
+    format_guest_features: true,
+    colourful_counts: true
 };
 let settings_base = {
     hue: {
@@ -369,6 +370,13 @@ let settings_base = {
         value: true,
         values: [true, false],
         type: 'toggle'
+    },
+    colourful_counts: {
+        css: 'colourful_counts',
+        unit: '',
+        value: true,
+        values: [true, false],
+        type: 'toggle'
     }
 };
 
@@ -418,7 +426,6 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
             patch_titles(document.body);
             patch_header_title(document.body);
             patch_artist_ranks(document.body);
-            patch_artist_ranks_in_grid_view(document.body);
         }
 
         // last.fm is a single page application
@@ -442,7 +449,6 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
                                 patch_titles(document.body);
                                 patch_header_title(document.body);
                                 patch_artist_ranks(document.body);
-                                patch_artist_ranks_in_grid_view(document.body);
                             }
                         }
                     }
@@ -1080,21 +1086,27 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
 
     // artist ranks
     function patch_artist_ranks(element) {
-        let personal_statistic = element.querySelector('.header-new--artist + .page-content .personal-stats-item--scrobbles');
+        let settings = JSON.parse(localStorage.getItem('bleh')) || create_settings_template();
 
-        if (personal_statistic == undefined)
-            return;
+        if (settings.colourful_counts) {
+            patch_artist_ranks_in_grid_view(document.body);
 
-        if (!personal_statistic.hasAttribute('data-kate-processed')) {
-            personal_statistic.setAttribute('data-kate-processed','true');
+            let personal_statistic = element.querySelector('.header-new--artist + .page-content .personal-stats-item--scrobbles');
 
-            let scrobbles = parseInt(personal_statistic.querySelector('.link-block-target').textContent.replaceAll(',',''));
-            let parsed_scrobble_as_rank = parse_scrobbles_as_rank(scrobbles);
+            if (personal_statistic == undefined)
+                return;
 
-            personal_statistic.setAttribute('data-bleh--scrobble-milestone',parsed_scrobble_as_rank.milestone);
-            personal_statistic.style.setProperty('--hue',parsed_scrobble_as_rank.hue);
-            personal_statistic.style.setProperty('--sat',parsed_scrobble_as_rank.sat);
-            personal_statistic.style.setProperty('--lit',parsed_scrobble_as_rank.lit);
+            if (!personal_statistic.hasAttribute('data-kate-processed')) {
+                personal_statistic.setAttribute('data-kate-processed','true');
+
+                let scrobbles = parseInt(personal_statistic.querySelector('.link-block-target').textContent.replaceAll(',',''));
+                let parsed_scrobble_as_rank = parse_scrobbles_as_rank(scrobbles);
+
+                personal_statistic.setAttribute('data-bleh--scrobble-milestone',parsed_scrobble_as_rank.milestone);
+                personal_statistic.style.setProperty('--hue',parsed_scrobble_as_rank.hue);
+                personal_statistic.style.setProperty('--sat',parsed_scrobble_as_rank.sat);
+                personal_statistic.style.setProperty('--lit',parsed_scrobble_as_rank.lit);
+            }
         }
     }
 
@@ -1576,6 +1588,143 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
                         </div>
                         <div class="toggle-wrap">
                             <button class="toggle" id="toggle-underline_links" onclick="_update_item('underline_links')" aria-checked="false">
+                                <div class="dot"></div>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="sep"></div>
+                    <div class="inner-preview pad">
+                        <div class="personal-stats-preview bleh--personal-stats-if-colourful">
+                            <div class="personal-stats-item personal-stats-item--scrobbles link-block js-link-block" data-kate-processed="true" data-bleh--scrobble-milestone="10" style="--hue: -14.921125; --sat: 1.5; --lit: 0.875;">
+                                <div class="personal-stats-inner">
+                                    <ul class="header-metadata">
+                                        <li class="header-metadata-item">
+                                            <h4 class="header-metadata-title">
+                                                Your scrobbles
+                                            </h4>
+                                            <div class="header-metadata-display">
+                                                <a class="link-block-target">
+                                                    13,041
+                                                </a>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                    <span class="avatar personal-stats-avatar">
+                                        <img src="https://lastfm.freetls.fastly.net/i/u/avatar70s/198d1a3bd66a0d586e8e7af8a31febe4.jpg" alt="Your avatar" loading="lazy">
+                                        <span class="avatar-status-dot user-status--bleh-queen user-status--bleh-user-cutensilly" data-kate-processed="true"></span>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="personal-stats-item personal-stats-item--scrobbles link-block js-link-block" data-kate-processed="true" data-bleh--scrobble-milestone="5" style="--hue: 96.59066666666666; --sat: 1.35; --lit: 0.925;">
+                                <div class="personal-stats-inner">
+                                    <ul class="header-metadata">
+                                        <li class="header-metadata-item">
+                                            <h4 class="header-metadata-title">
+                                                Your scrobbles
+                                            </h4>
+                                            <div class="header-metadata-display">
+                                                <a class="link-block-target">
+                                                    1,627
+                                                </a>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                    <span class="avatar personal-stats-avatar">
+                                        <img src="https://lastfm.freetls.fastly.net/i/u/avatar70s/198d1a3bd66a0d586e8e7af8a31febe4.jpg" alt="Your avatar" loading="lazy">
+                                        <span class="avatar-status-dot user-status--bleh-queen user-status--bleh-user-cutensilly" data-kate-processed="true"></span>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="personal-stats-preview bleh--personal-stats-if-not-colourful">
+                            <div class="personal-stats-item personal-stats-item--scrobbles link-block js-link-block">
+                                <div class="personal-stats-inner">
+                                    <ul class="header-metadata">
+                                        <li class="header-metadata-item">
+                                            <h4 class="header-metadata-title">
+                                                Your scrobbles
+                                            </h4>
+                                            <div class="header-metadata-display">
+                                                <a class="link-block-target">
+                                                    13,041
+                                                </a>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                    <span class="avatar personal-stats-avatar">
+                                        <img src="https://lastfm.freetls.fastly.net/i/u/avatar70s/198d1a3bd66a0d586e8e7af8a31febe4.jpg" alt="Your avatar" loading="lazy">
+                                        <span class="avatar-status-dot user-status--bleh-queen user-status--bleh-user-cutensilly" data-kate-processed="true"></span>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="personal-stats-item personal-stats-item--scrobbles link-block js-link-block">
+                                <div class="personal-stats-inner">
+                                    <ul class="header-metadata">
+                                        <li class="header-metadata-item">
+                                            <h4 class="header-metadata-title">
+                                                Your scrobbles
+                                            </h4>
+                                            <div class="header-metadata-display">
+                                                <a class="link-block-target">
+                                                    1,627
+                                                </a>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                    <span class="avatar personal-stats-avatar">
+                                        <img src="https://lastfm.freetls.fastly.net/i/u/avatar70s/198d1a3bd66a0d586e8e7af8a31febe4.jpg" alt="Your avatar" loading="lazy">
+                                        <span class="avatar-status-dot user-status--bleh-queen user-status--bleh-user-cutensilly" data-kate-processed="true"></span>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sep"></div>
+                        <table class="chartlist chartlist--with-index chartlist--with-index--length-2 chartlist--with-image chartlist--with-bar">
+                            <tbody>
+                                <tr class="chartlist-row chartlist-row--highlight">
+                                    <td class="chartlist-index">
+                                        1
+                                    </td>
+                                    <td class="chartlist-image">
+                                        <span class="avatar">
+                                            <img src="https://lastfm.freetls.fastly.net/i/u/avatar70s/198d1a3bd66a0d586e8e7af8a31febe4.jpg" alt="Your avatar" loading="lazy">
+                                        </span>
+                                    </td>
+                                    <td class="chartlist-name">
+                                        <a class="link-block-target">
+                                            cutensilly
+                                        </a>
+                                    </td>
+                                    <td class="chartlist-bar">
+                                        <span class="chartlist-count-bar bleh--personal-stats-if-colourful" data-bleh--scrobble-milestone="11" style="--hue: -33.2225; --sat: 1.3286979166666666; --lit: 0.8681479166666667;">
+                                            <span class="chartlist-count-bar-link">
+                                                <span class="chartlist-count-bar-slug" style="width:36.08268870690144%;"></span>
+                                                <span class="chartlist-count-bar-value">
+                                                    19,078
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="chartlist-count-bar bleh--personal-stats-if-not-colourful">
+                                            <span class="chartlist-count-bar-link">
+                                                <span class="chartlist-count-bar-slug" style="width:36.08268870690144%;"></span>
+                                                <span class="chartlist-count-bar-value">
+                                                    19,078
+                                                </span>
+                                            </span>
+                                        </span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="toggle-container" id="container-colourful_counts">
+                        <button class="btn reset" onclick="_reset_item('colourful_counts')">Reset to default</button>
+                        <div class="heading">
+                            <h5>Use a colour gradient for all-time charts</h5>
+                            <p>Assigns a colour from a gradient based on your position in all-time artist scrobbles.</p>
+                        </div>
+                        <div class="toggle-wrap">
+                            <button class="toggle" id="toggle-colourful_counts" onclick="_update_item('colourful_counts')" aria-checked="true">
                                 <div class="dot"></div>
                             </button>
                         </div>
@@ -2404,7 +2553,7 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
 
 
                     // artist statistic
-                    if (track_image.classList.contains('avatar')) {
+                    if (track_image.classList.contains('avatar') && settings.colourful_counts) {
                         patch_artist_ranks_in_list_view(track);
                         return;
                     }

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -402,6 +402,7 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
             patch_lastfm_settings(document.body);
             patch_titles(document.body);
             patch_header_title(document.body);
+            patch_artist_ranks(document.body);
         }
 
         // last.fm is a single page application
@@ -424,6 +425,7 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
                                 patch_lastfm_settings(document.body);
                                 patch_titles(document.body);
                                 patch_header_title(document.body);
+                                patch_artist_ranks(document.body);
                             }
                         }
                     }
@@ -1053,6 +1055,62 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
                 });
                 element.setAttribute('title','');
             }
+        }
+    }
+
+
+
+
+    // artist ranks
+    function patch_artist_ranks(element) {
+        let personal_statistic = document.querySelector('.personal-stats-item--scrobbles');
+
+        if (personal_statistic == undefined)
+            return;
+
+        if (!personal_statistic.hasAttribute('data-kate-processed')) {
+            personal_statistic.setAttribute('data-kate-processed','true');
+
+            let scrobbles = parseInt(personal_statistic.querySelector('.link-block-target').textContent.replaceAll(',',''));
+            let scrobble_milestone = 0;
+
+            if (scrobbles > 150_000)
+                scrobble_milestone = 14;
+            else if (scrobbles > 100_000)
+                scrobble_milestone = 13;
+            else if (scrobbles > 75_000)
+                scrobble_milestone = 12;
+            else if (scrobbles > 65_000)
+                scrobble_milestone = 11;
+            else if (scrobbles > 50_000)
+                scrobble_milestone = 10;
+            else if (scrobbles > 35_000)
+                scrobble_milestone = 9;
+            else if (scrobbles > 25_000)
+                scrobble_milestone = 8;
+            else if (scrobbles > 15_000)
+                scrobble_milestone = 7;
+            else if (scrobbles > 9_000)
+                scrobble_milestone = 6;
+            else if (scrobbles > 5_000)
+                scrobble_milestone = 5;
+            else if (scrobbles > 3_500)
+                scrobble_milestone = 4;
+            else if (scrobbles > 2_000)
+                scrobble_milestone = 3;
+            else if (scrobbles > 1_000)
+                scrobble_milestone = 2;
+            else if (scrobbles > 500)
+                scrobble_milestone = 1;
+            else if (scrobbles > 100)
+                scrobble_milestone = 0;
+
+            console.info('bleh - scrobble milestone for artist is',scrobble_milestone,'with',scrobbles,'scrobbles');
+
+            personal_statistic.setAttribute('data-bleh--scrobble-milestone',scrobble_milestone);
+            personal_statistic.style.setProperty('--hue',ranks[scrobble_milestone].hue);
+            personal_statistic.style.setProperty('--sat',ranks[scrobble_milestone].sat);
+            personal_statistic.style.setProperty('--lit',ranks[scrobble_milestone].lit);
         }
     }
 

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -57,6 +57,84 @@ let song_title_corrections = {
     }
 };
 
+let ranks = {
+    0: {
+        hue: 200,
+        sat: 1.5,
+        lit: 0.925
+    },
+    1: {
+        hue: 180,
+        sat: 1.5,
+        lit: 0.925
+    },
+    2: {
+        hue: 160,
+        sat: 1.5,
+        lit: 0.925
+    },
+    3: {
+        hue: 148,
+        sat: 1.35,
+        lit: 0.925
+    },
+    4: {
+        hue: 130,
+        sat: 1.35,
+        lit: 0.925
+    },
+    5: {
+        hue: 103,
+        sat: 1.35,
+        lit: 0.925
+    },
+    6: {
+        hue: 80,
+        sat: 1.35,
+        lit: 0.925
+    },
+    7: {
+        hue: 60,
+        sat: 1.375,
+        lit: 0.95
+    },
+    8: {
+        hue: 25,
+        sat: 1.425,
+        lit: 0.925
+    },
+    9: {
+        hue: 4,
+        sat: 1.425,
+        lit: 0.925
+    },
+    10: {
+        hue: 350,
+        sat: 1.5,
+        lit: 0.875
+    },
+    11: {
+        hue: 332,
+        sat: 1.5,
+        lit: 0.875
+    },
+    12: {
+        hue: 290,
+        sat: 0.875,
+        lit: 0.85
+    },
+    13: {
+        hue: 246,
+        sat: 1.2,
+        lit: 0.9
+    },
+    14: {
+        hue: 240,
+        sat: 1,
+        lit: 0.575
+    }
+}
+
 let includes = {
     guests: [
         '- feat', '(feat', '[feat', ' feat.',

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -1110,6 +1110,27 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
         });
     }
 
+    function patch_artist_ranks_in_list_view(track) {
+        let count_bar = track.querySelector('.chartlist-count-bar');
+
+        if (count_bar == undefined)
+            return;
+
+        let count = parseInt(count_bar.querySelector('.chartlist-count-bar-value').textContent.replaceAll(',','').replace(' scrobbles',''));
+        console.info('count', count);
+
+        if (!count_bar.hasAttribute('data-kate-processed')) {
+            count_bar.setAttribute('data-kate-processed','true');
+
+            let parsed_scrobble_as_rank = parse_scrobbles_as_rank(count);
+
+            count_bar.setAttribute('data-bleh--scrobble-milestone',parsed_scrobble_as_rank.milestone);
+            count_bar.style.setProperty('--hue',parsed_scrobble_as_rank.hue);
+            count_bar.style.setProperty('--sat',parsed_scrobble_as_rank.sat);
+            count_bar.style.setProperty('--lit',parsed_scrobble_as_rank.lit);
+        }
+    }
+
 
     function parse_scrobbles_as_rank(scrobbles) {
         let scrobble_milestone = 0;
@@ -2406,10 +2427,16 @@ let bleh_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh$');
 
 
                     // image
-                    let track_image = track.querySelector('.chartlist-image img');
+                    let track_image = track.querySelector('.chartlist-image span');
+                    let track_image_img = track_image.querySelector('img');
                     tippy(track_image, {
-                        content: track_image.getAttribute('alt')
+                        content: track_image_img.getAttribute('alt')
                     })
+
+
+                    // artist statistic
+                    if (track_image.classList.contains('avatar'))
+                        patch_artist_ranks_in_list_view(track);
                 }
             });
             } catch(e) {console.error('AA',e)}


### PR DESCRIPTION
this PR implements a colour gradient system that is applied based on your scrobbles on an artist

(these screenshots show outdated colours, but you get the point)

it is shown on artist pages here:
![image](https://github.com/katelyynn/bleh/assets/46572320/b73defe7-748f-4775-bf39-0597797b996a)

in (ALL-TIME) grids like so:
![image](https://github.com/katelyynn/bleh/assets/46572320/fb54c5e2-9f08-47e8-b22e-bfd6c6e7c592)

in (ALL-TIME) artist lists and listeners u know like so:
![image](https://github.com/katelyynn/bleh/assets/46572320/9685ef9b-eb6e-4959-bc56-d20d4492dbd5)

