### PR TITLE
feat: custom overlay sliders

### DIFF
--- a/fm/bleh.css
+++ b/fm/bleh.css
@@ -13095,7 +13095,7 @@ code, kbd, samp {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(50px, 1fr));
     gap: 4px;
-    height: 50px;
+    height: 100%;
 }
 
 .palette.options {
@@ -13364,49 +13364,50 @@ input[type="range"] {
     height: 32px;
     border-radius: var(--item-small-radius);
     overflow: hidden;
+}
 
-    &::-webkit-slider-runnable-track {
-        height: 22px;
-        background: hsl(var(--b4));
-        box-shadow: 0 0 0 1px hsla(var(--b3), 40%) inset, var(--interact-shadow);
-        border-radius: var(--item-small-radius);
+.slider-track {
+    display: flex;
+    background: hsla(var(--b6), 20%);
+    box-shadow: 0 0 0 1px var(--card-border-base) inset;
+    border-radius: var(--item-med-radius);
+    width: calc(100% - (30px + var(--card-gap))); /* 30px = value width */
+    height: 20px;
+    position: absolute;
+
+    pointer-events: none;
+
+    .slider-fill {
+        display: flex;
+        width: var(--percent);
+        background-color: hsl(var(--h3));
+        border-radius: var(--item-med-radius);
+        box-shadow: 0 0 0 1px hsla(var(--h2), 40%) inset;
     }
-    &::-moz-range-track {
-        height: 22px;
-        background: hsl(var(--b4));
-        box-shadow: 0 0 0 1px hsla(var(--b3), 40%) inset, var(--interact-shadow);
-        border-radius: var(--item-small-radius);
+
+    .slider-nub {
+        display: flex;
+        width: 12px;
+        background-color: hsl(var(--h4));
+        border: 2px solid hsl(var(--b5));
+        border-radius: var(--item-med-radius);
+        margin: -5px -5px;
     }
 
     #container-hue & {
-        &::-webkit-slider-runnable-track {
-            background: linear-gradient(to right,
-                hsl(0, var(--h3-sat), var(--h3-lit)) 0%,
-                hsl(60, var(--h3-sat), var(--h3-lit)) 16.67%,
-                hsl(120, var(--h3-sat), var(--h3-lit)) 33.33%,
-                hsl(180, var(--h3-sat), var(--h3-lit)) 50%,
-                hsl(240, var(--h3-sat), var(--h3-lit)) 66.67%,
-                hsl(300, var(--h3-sat), var(--h3-lit)) 83.33%,
-                hsl(360, var(--h3-sat), var(--h3-lit)) 100%
-            );
-        }
-        &::-moz-range-track {
-            background: linear-gradient(to right,
-                hsl(0, var(--h3-sat), var(--h3-lit)) 0%,
-                hsl(60, var(--h3-sat), var(--h3-lit)) 16.67%,
-                hsl(120, var(--h3-sat), var(--h3-lit)) 33.33%,
-                hsl(180, var(--h3-sat), var(--h3-lit)) 50%,
-                hsl(240, var(--h3-sat), var(--h3-lit)) 66.67%,
-                hsl(300, var(--h3-sat), var(--h3-lit)) 83.33%,
-                hsl(360, var(--h3-sat), var(--h3-lit)) 100%
-            );
-        }
+        box-shadow: unset;
+        background: linear-gradient(to right,
+            hsl(0, var(--h3-sat), var(--h3-lit)) 0%,
+            hsl(60, var(--h3-sat), var(--h3-lit)) 16.67%,
+            hsl(120, var(--h3-sat), var(--h3-lit)) 33.33%,
+            hsl(180, var(--h3-sat), var(--h3-lit)) 50%,
+            hsl(240, var(--h3-sat), var(--h3-lit)) 66.67%,
+            hsl(300, var(--h3-sat), var(--h3-lit)) 83.33%,
+            hsl(360, var(--h3-sat), var(--h3-lit)) 100%
+        );
 
-        &::-webkit-progress-value {
-            background: none;
-        }
-        &::-moz-range-progress {
-            background: none;
+        .slider-fill {
+            opacity: 0;
         }
     }
 }
@@ -13417,25 +13418,22 @@ input[type="range"]::-webkit-slider-thumb {
     /**/
     width: 8px;
     height: 28px;
-    background-color: hsl(var(--h2));
-    border-radius: var(--item-small-radius);
-    border: 2px solid hsl(var(--b5));
+    background-color: transparent;
 }
 input[type="range"]::-moz-range-thumb {
     width: 8px;
     height: 28px;
-    background-color: hsl(var(--h2));
-    border-radius: var(--item-small-radius);
-    border: 2px solid hsl(var(--b5));
+    background-color: transparent;
+    border: unset;
 }
 
 input[type="range"]::-webkit-progress-value {
-    background: hsl(var(--h3));
+    background: transparent;
     height: 22px;
     border-radius: var(--item-small-radius);
 }
 input[type="range"]::-moz-range-progress {
-    background: hsl(var(--h3));
+    background: transparent;
     height: 22px;
     border-radius: var(--item-small-radius);
 }

--- a/fm/bleh.css
+++ b/fm/bleh.css
@@ -5,7 +5,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Ubuntu+Sans:ital,wght@0,100..800;1,100..800&display=swap');
 
 body {
-    --version-build: '2024.1019';
+    --version-build: '2024.1020';
 
     --hue:  var(--hue-over,
             var(--hue-album,

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -13105,7 +13105,7 @@ code, kbd, samp {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(50px, 1fr));
     gap: 4px;
-    height: 50px;
+    height: 100%;
 }
 
 .palette.options {
@@ -13374,49 +13374,50 @@ input[type="range"] {
     height: 32px;
     border-radius: var(--item-small-radius);
     overflow: hidden;
+}
 
-    &::-webkit-slider-runnable-track {
-        height: 22px;
-        background: hsl(var(--b4));
-        box-shadow: 0 0 0 1px hsla(var(--b3), 40%) inset, var(--interact-shadow);
-        border-radius: var(--item-small-radius);
+.slider-track {
+    display: flex;
+    background: hsla(var(--b6), 20%);
+    box-shadow: 0 0 0 1px var(--card-border-base) inset;
+    border-radius: var(--item-med-radius);
+    width: calc(100% - (30px + var(--card-gap))); /* 30px = value width */
+    height: 20px;
+    position: absolute;
+
+    pointer-events: none;
+
+    .slider-fill {
+        display: flex;
+        width: var(--percent);
+        background-color: hsl(var(--h3));
+        border-radius: var(--item-med-radius);
+        box-shadow: 0 0 0 1px hsla(var(--h2), 40%) inset;
     }
-    &::-moz-range-track {
-        height: 22px;
-        background: hsl(var(--b4));
-        box-shadow: 0 0 0 1px hsla(var(--b3), 40%) inset, var(--interact-shadow);
-        border-radius: var(--item-small-radius);
+
+    .slider-nub {
+        display: flex;
+        width: 12px;
+        background-color: hsl(var(--h4));
+        border: 2px solid hsl(var(--b5));
+        border-radius: var(--item-med-radius);
+        margin: -5px -5px;
     }
 
     #container-hue & {
-        &::-webkit-slider-runnable-track {
-            background: linear-gradient(to right,
-                hsl(0, var(--h3-sat), var(--h3-lit)) 0%,
-                hsl(60, var(--h3-sat), var(--h3-lit)) 16.67%,
-                hsl(120, var(--h3-sat), var(--h3-lit)) 33.33%,
-                hsl(180, var(--h3-sat), var(--h3-lit)) 50%,
-                hsl(240, var(--h3-sat), var(--h3-lit)) 66.67%,
-                hsl(300, var(--h3-sat), var(--h3-lit)) 83.33%,
-                hsl(360, var(--h3-sat), var(--h3-lit)) 100%
-            );
-        }
-        &::-moz-range-track {
-            background: linear-gradient(to right,
-                hsl(0, var(--h3-sat), var(--h3-lit)) 0%,
-                hsl(60, var(--h3-sat), var(--h3-lit)) 16.67%,
-                hsl(120, var(--h3-sat), var(--h3-lit)) 33.33%,
-                hsl(180, var(--h3-sat), var(--h3-lit)) 50%,
-                hsl(240, var(--h3-sat), var(--h3-lit)) 66.67%,
-                hsl(300, var(--h3-sat), var(--h3-lit)) 83.33%,
-                hsl(360, var(--h3-sat), var(--h3-lit)) 100%
-            );
-        }
+        box-shadow: unset;
+        background: linear-gradient(to right,
+            hsl(0, var(--h3-sat), var(--h3-lit)) 0%,
+            hsl(60, var(--h3-sat), var(--h3-lit)) 16.67%,
+            hsl(120, var(--h3-sat), var(--h3-lit)) 33.33%,
+            hsl(180, var(--h3-sat), var(--h3-lit)) 50%,
+            hsl(240, var(--h3-sat), var(--h3-lit)) 66.67%,
+            hsl(300, var(--h3-sat), var(--h3-lit)) 83.33%,
+            hsl(360, var(--h3-sat), var(--h3-lit)) 100%
+        );
 
-        &::-webkit-progress-value {
-            background: none;
-        }
-        &::-moz-range-progress {
-            background: none;
+        .slider-fill {
+            opacity: 0;
         }
     }
 }
@@ -13427,25 +13428,22 @@ input[type="range"]::-webkit-slider-thumb {
     /**/
     width: 8px;
     height: 28px;
-    background-color: hsl(var(--h2));
-    border-radius: var(--item-small-radius);
-    border: 2px solid hsl(var(--b5));
+    background-color: transparent;
 }
 input[type="range"]::-moz-range-thumb {
     width: 8px;
     height: 28px;
-    background-color: hsl(var(--h2));
-    border-radius: var(--item-small-radius);
-    border: 2px solid hsl(var(--b5));
+    background-color: transparent;
+    border: unset;
 }
 
 input[type="range"]::-webkit-progress-value {
-    background: hsl(var(--h3));
+    background: transparent;
     height: 22px;
     border-radius: var(--item-small-radius);
 }
 input[type="range"]::-moz-range-progress {
-    background: hsl(var(--h3));
+    background: transparent;
     height: 22px;
     border-radius: var(--item-small-radius);
 }

--- a/fm/bleh.user.css
+++ b/fm/bleh.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           bleh (dev)
 @namespace      github.com/katelyynn/bleh
-@version        2024.1019
+@version        2024.1020
 @license        GPL-3.0
 @author         kate
 @updateURL      https://github.com/katelyynn/bleh/raw/uwu/fm/bleh.user.css
@@ -15,7 +15,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Ubuntu+Sans:ital,wght@0,100..800;1,100..800&display=swap');
 
 body {
-    --version-build: '2024.1019';
+    --version-build: '2024.1020';
 
     --hue:  var(--hue-over,
             var(--hue-album,

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -5855,6 +5855,7 @@ let setup_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh/setup$');
                             <p>${trans[lang].settings.customise.gloss.bio}</p>
                         </div>
                         <div class="slider">
+                            <div class="slider-track" id="slider-track-gloss"><div class="slider-fill"></div><div class="slider-nub"></div></div>
                             <input type="range" min="0" max="1" value="0" step="0.05" id="slider-gloss" oninput="_update_item('gloss', this.value)">
                             <p id="value-gloss">0</p>
                         </div>
@@ -6965,8 +6966,11 @@ let setup_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh/setup$');
         if (settings_base[item].type == 'slider') {
             // text to show current slider value
             try {
+                let slider = document.getElementById(`slider-${item}`);
+
                 document.getElementById(`value-${item}`).textContent = `${settings[item]}${settings_base[item].unit}`;
-                document.getElementById(`slider-${item}`).value = settings[item];
+                slider.value = settings[item];
+                document.getElementById(`slider-track-${item}`).style.setProperty('--percent', `${(settings[item] / slider.getAttribute('max')) * 100}%`);
 
                 if (settings[item] != settings_base[item].value)
                     document.getElementById(`container-${item}`).classList.add('modified');
@@ -7231,6 +7235,7 @@ let setup_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh/setup$');
                 <h5>${trans[lang].settings.customise.colours.modals.custom_colour.hue}</h5>
             </div>
             <div class="slider">
+                <div class="slider-track" id="slider-track-hue"><div class="slider-fill"></div><div class="slider-nub"></div></div>
                 <input type="range" min="0" max="360" value="${settings.hue}" id="slider-hue" oninput="_update_item('hue', this.value)">
                 <p id="value-hue">${settings.hue}${settings_base.hue.unit}</p>
             </div>
@@ -7246,6 +7251,7 @@ let setup_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh/setup$');
                 <h5>${trans[lang].settings.customise.colours.modals.custom_colour.sat}</h5>
             </div>
             <div class="slider">
+                <div class="slider-track" id="slider-track-sat"><div class="slider-fill"></div><div class="slider-nub"></div></div>
                 <input type="range" min="0" max="1.5" value="${settings.sat}" step="0.025" id="slider-sat" oninput="_update_item('sat', this.value)">
                 <p id="value-sat">${settings.sat}${settings_base.sat.unit}</p>
             </div>
@@ -7261,6 +7267,7 @@ let setup_regex = new RegExp('^https://www\.last\.fm/[a-z]+/bleh/setup$');
                 <h5>${trans[lang].settings.customise.colours.modals.custom_colour.lit}</h5>
             </div>
             <div class="slider">
+                <div class="slider-track" id="slider-track-lit"><div class="slider-fill"></div><div class="slider-nub"></div></div>
                 <input type="range" min="0" max="1.5" value="${settings.lit}" step="0.025" id="slider-lit" oninput="_update_item('lit', this.value)">
                 <p id="value-lit">${settings.lit}${settings_base.lit.unit}</p>
             </div>

--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         bleh
 // @namespace    http://last.fm/
-// @version      2024.1019
+// @version      2024.1020
 // @description  bleh!!! ^-^
 // @author       kate
 // @match        https://www.last.fm/*
@@ -18,7 +18,7 @@
 // ==/UserScript==
 
 let version = {
-    build: '2024.1019',
+    build: '2024.1020',
     sku: 'falter',
     feature_flags: {
         bleh_settings_tabs: {


### PR DESCRIPTION
- closes #65 

range sliders are now visually hidden, only used for input. custom created sliders are now displayed and inherit their width from the hidden slider

before (firefox):
![378197230-9db509f0-7169-4c86-8de4-8b1f903e0356](https://github.com/user-attachments/assets/954675ac-4c19-4a3c-993b-30b4f05f9c6d)
before (chrome):
![378197250-b0890b9d-fbcd-4333-a8a3-91d1aabf88cd](https://github.com/user-attachments/assets/566734d5-96d6-4f84-b666-c9739b238852)

after (both):
![image](https://github.com/user-attachments/assets/b87ea27c-21ae-4b7f-91b1-aa19f0f05d84)
