### PR TITLE
Fix typo in Spanish listens label

### DIFF
--- a/fm/bleh.user.js
+++ b/fm/bleh.user.js
@@ -59598,7 +59598,7 @@ ${e ? html.node`<span class="error-type">${e.name}</span>: ${e.message}` : ""}</
       count: {
         en: "{c} listens",
         de: "{c} Scrobbles",
-        es: "{c] scrobblings",
+        es: "{c} scrobblings",
         it: "{c} scrobbling",
         pt: "{c} scrobbles",
         sv: "{c} skrobblingar",

--- a/fm/src/build/trans.js
+++ b/fm/src/build/trans.js
@@ -943,7 +943,7 @@ export const trans = {
         count: {
             en: '{c} listens',
             de: '{c} Scrobbles',
-            es: '{c] scrobblings',
+            es: '{c} scrobblings',
             it: '{c} scrobbling',
             pt: '{c} scrobbles',
             sv: '{c} skrobblingar',
@@ -1261,7 +1261,7 @@ export const trans = {
         // the space on the end is intentional
         en: 'Your theme preference will be either {day} or {night}, based on your system. ',
         de: 'Dein bevorzugtes Farbschema wird entweder {day} oder {night} sein, basierend auf deinem System. ',
-        es: 'El aspecto elegido será {day] o {night}, basándose en tu dispositivo. ',
+        es: 'El aspecto elegido será {day} o {night}, basándose en tu dispositivo. ',
         it: 'Il tuo tema selezionato sarà {day} o {night}, in base al tuo tema di sistema. ',
         pt: 'Sua preferência de tema será {day} ou {night}, com base no seu sistema. ',
         sv: 'Ditt föredragna tema blir antigen {day} eller {night}, beroende på ditt system. ',
@@ -5951,7 +5951,7 @@ export const trans = {
     last_count_days: {
         en: 'Last {c} days',
         de: 'Letzte {c} Tage',
-        es: 'Últimos {c] días',
+        es: 'Últimos {c} días',
         it: 'Ultimi {c} giorni',
         pt: 'Últimos {c} dias',
         ja: '過去 {c} 日間',


### PR DESCRIPTION
Corrected a typo in the Spanish translation for the listens count label, changing '{c] scrobblings' to '{c} scrobblings'.