### PR TITLE
Fix chart rank number alignment

### DIFF
--- a/fm/src/styles/music/chart.css
+++ b/fm/src/styles/music/chart.css
@@ -162,7 +162,7 @@
 
                     .charts-list-rank-overlay {
                         position: absolute;
-                        bottom: 0;
+                        bottom: 8px;
                         left: 8px;
                         font-family: var(--font-head);
                         font-size: 60px;


### PR DESCRIPTION
I noticed that the rank number on the charts page wasn't offset vertically

Before:
<img width="647" height="290" alt="image" src="https://github.com/user-attachments/assets/d212248d-4b12-4970-80a0-232440f56314" />
After:
<img width="651" height="273" alt="image" src="https://github.com/user-attachments/assets/ff430bb8-7a65-44c3-b9d6-4d811820e581" />

