### PR TITLE
feat: enforce csp policies

### DIFF
--- a/fm/src/csp.ts
+++ b/fm/src/csp.ts
@@ -87,6 +87,7 @@ const CspPolicies: PolicyMap = {
 		'wss://html-load.cc',
 		'*.newrelic.com',
 		'status.cafe',
+		'*.github.io',
 	],
 	'font-src': [
 		"'self'",

--- a/fm/src/csp.ts
+++ b/fm/src/csp.ts
@@ -1,0 +1,109 @@
+/**
+ * bleh, an extension for the music site Last.fm
+ * Copyright (c) 2024-2026 katelyn and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+type PolicyMap = {
+	'default-src': string[];
+	'script-src': string[];
+	'style-src': string[];
+	'img-src': string[];
+	'connect-src': string[];
+	'font-src': string[];
+};
+
+const CspPolicies: PolicyMap = {
+	'default-src': [
+		"'self'",
+
+		// stuff that last.fm uses
+		'youtube.com',
+		'youtube-nocookie.com',
+		'*.youtube.com',
+		'*.youtube-nocookie.com',
+	],
+	'script-src': [
+		"'self'",
+		"'unsafe-inline'",
+		"'unsafe-eval'",
+
+		// stuff that last.fm uses
+		'cdn.jsdelivr.net',
+		'cdnjs.cloudflare.com',
+		'cdn.cookielaw.org',
+		'google.com',
+		'youtube.com',
+		'youtube-nocookie.com',
+		'*.youtube.com',
+		'*.youtube-nocookie.com',
+		'*.githack.com',
+		'*.newrelic.com',
+		'a.pub.network',
+		'tags.tiqcdn.com',
+		'html-load.cc',
+		'srv.tunefindforfans.com',
+	],
+	'style-src': [
+		"'self'",
+		"'unsafe-inline'",
+
+		'fonts.googleapis.com',
+
+		// stuff that last.fm uses
+		'static.cheftoondiligord.site',
+		'a.pub.network',
+	],
+	'img-src': [
+		"'self'",
+		'data:',
+
+		// stuff that last.fm uses
+		'*.fastly.net',
+		'cdn.cookielaw.org',
+		'img.youtube.com',
+
+		// various image hosts
+		'files.catbox.moe',
+		'*.klipy.com',
+		'*.tenor.com',
+		'*.tenor.co',
+		'images.weserv.nl',
+		'icons.duckduckgo.com',
+
+		// various git sites
+		'github.com',
+		'gitlab.com',
+		'codeberg.org',
+		'*.github.io',
+		'*.gitlab.io',
+		'*.codeberg.page',
+		'raw.githubusercontent.com',
+	],
+	'connect-src': [
+		"'self'",
+		'cdn.cookielaw.org',
+		'geolocation.onetrust.com',
+		'wss://html-load.cc',
+		'*.newrelic.com',
+		'status.cafe',
+	],
+	'font-src': [
+		"'self'",
+		'fonts.gstatic.com',
+		'*.github.io',
+	],
+};
+
+function buildCSP(policies: PolicyMap) {
+	return Object.entries(policies)
+		.map(([policy, sources]) => `${policy} ${sources.join(' ')}`)
+		.join('; ');
+}
+
+export function applyCSP() {
+	const elem = document.createElement('meta');
+	elem.setAttribute('http-equiv', 'Content-Security-Policy');
+	elem.setAttribute('content', buildCSP(CspPolicies));
+	document.head.prepend(elem);
+}

--- a/fm/src/main.js
+++ b/fm/src/main.js
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import { applyCSP } from '@/csp';
+applyCSP();
+
 import { log } from './build/log';
 import { bleh } from './page';
 


### PR DESCRIPTION
adds some (probably overkill) CSP policies to prevent things from untrusted sites from loading

<img width="569" height="45" alt="image" src="https://github.com/user-attachments/assets/1839dee6-1dd5-4309-ab65-d4324026e0de" />

i tested this pretty thoroughly and it does not seem to break last.fm at all